### PR TITLE
Adding black tick marks in absence of grid lines and change tick label style

### DIFF
--- a/js/src/Axis.js
+++ b/js/src/Axis.js
@@ -478,17 +478,21 @@ define(["jupyter-js-widgets", "d3", "./utils", "underscore"],
             }
 
             if (grid_type !== "none") {
-                this.axis.innerTickSize(tickSize).outerTickSize(6);
+                this.axis.innerTickSize(tickSize).outerTickSize(0);
             } else {
-                this.axis.tickSize(6);
+                this.axis.tickSize(5);
             }
+
+            this.g_axisline
+                .selectAll(".tick")
+                .classed("short", grid_type === "none");
 
             this.g_axisline
                 .transition().duration(animation_duration)
                 .call(this.axis)
                 .selectAll(".tick line")
                 .attr(is_x ? "y1" : "x1",
-                      (this.offset_scale && grid_type !== "none")? tickOffset : null)
+                      (this.offset_scale && grid_type !== "none") ? tickOffset : null)
                 .style("stroke-dasharray", grid_type === "dashed" ? ("5, 5") : null);
 
             if (this.model.get("grid_color")) {

--- a/js/src/bqplot.less
+++ b/js/src/bqplot.less
@@ -125,9 +125,6 @@
     .common();
     svg.bqplot {
         .axis {
-            path, line {
-                stroke: #EEEEEE;
-            }
             rect {
                 stroke: white;
                 opacity: 1.0;
@@ -137,8 +134,10 @@
             	stroke-width: 1.4;
                 opacity: 1.0;
             }
+            .tick.short line {
+            	stroke: black;
+            }
             .tick text {
-                fill: #7f7f7f;
                 font: 12px sans-serif;
             }
         }


### PR DESCRIPTION
@dmadeka this is a PR to your PR which adds short (black) ticks when `grid_lines` is "none".
